### PR TITLE
Fix URL on /members/nik

### DIFF
--- a/src/content/member/nik.md
+++ b/src/content/member/nik.md
@@ -15,5 +15,5 @@ Most of my hobby projects are out there on public git repos (links below).
 #### Links
 
 - Website: [nikhilmwarrier.codeberg.page](https://nikhilmwarrier.codeberg.page/)
-- Codeberg: [codeberg.org/nikhilmwarrier](https://github.com/nikhilmwarrier)
+- Codeberg: [codeberg.org/nikhilmwarrier](https://codeberg.org/nikhilmwarrier)
 - GitHub: [github.com/nikhilmwarrier](https://github.com/nikhilmwarrier)


### PR DESCRIPTION
I slightly messed up the url to my codeberg page. This commit fixes that.